### PR TITLE
Issue#9 - Keeps array brackets on definition entry.

### DIFF
--- a/src/components/UploadOBTree.vue
+++ b/src/components/UploadOBTree.vue
@@ -58,7 +58,7 @@
             importedNodeSignifier: importedNode
           }"
         >
-          <span v-if="isArray && !expandDefn">
+          <span v-if="isArray">
             {{ shortenName + " " }}[ {{ arrayItemNameFromRef }} ]
           </span>
           <span v-else>


### PR DESCRIPTION
Makes the visual difference between items, where either is an array type, that have similar names or the same name clearer for the user.